### PR TITLE
Enhance export tool decision-making with dedicated prompt generation

### DIFF
--- a/core/nodes.py
+++ b/core/nodes.py
@@ -6,6 +6,7 @@ import re
 from history.chat_history import ChatHistory
 from core.openAI import OpenAIAPI
 from processors.tools import export_notes
+from prompts.export_tool import export_tool_prompt
 
 def route_input(state: ChatState) -> str:
     if "youtube.com" in state.user_input:
@@ -50,13 +51,12 @@ class GraphNodes:
         return state
     
     def normal_chat_response(self, state: ChatState) -> ChatState:
-        print("normal_chat_response")
         state.notes = self.generator.generate_response(state.user_input , state.transcript, self.chat_history.get_history())
         self._update_history(state)
         return state
     def should_export(self, state: ChatState):
         llm_with_tools = self.openai.bind_tools([export_notes])    
-        prompt = state.user_input + "\n\n" + state.notes
+        prompt = export_tool_prompt(state.user_input, state.notes , self.chat_history.get_history())
         messages = [{"role": "user", "content": prompt}]
         decision = llm_with_tools.invoke(messages)
         result = {"messages" : [decision]}

--- a/processors/tools.py
+++ b/processors/tools.py
@@ -10,7 +10,10 @@ logger = logging.getLogger(__name__)
 
 @tool
 def export_notes(notes: str, format: str = "txt") -> str:
-    """Export notes to a file
+    """Export notes to a file only if the user explicitly requests it.
+    This tool should not be invoked automatically by the LLM.
+    It should only be invoked when the user prompt contains the export request.
+    
     Args:
         notes (str): The notes to export
         format (str): The format to export the notes in

--- a/prompts/export_tool.py
+++ b/prompts/export_tool.py
@@ -1,0 +1,14 @@
+def export_tool_prompt(user_input: str, notes: str, history: list[dict]) -> str:
+    return (
+        "You are a helpful assistant that can analyze the user prompt"
+        "Based on the user prompt decide if you want to call the tools or not."
+        "Our system is such that we work youtube to notes generation."
+        "Our system contains the notes , we can perform various operations on it using the tools."
+        "NOTE: If the user prompt contains anything related to the tool call , then we will call the tool only in that case."
+        "We will be providing you with the user input and the generated notes."
+        "We will be providing you with the chat history till now as well so that you can properly generate the arguments for the tool calls if needed."
+        f"<user_input>\n{user_input}\n</user_input>\n"
+        f"<notes>\n{notes}\n</notes>\n"
+        "Would you like to export these notes to a file? (yes/no)\n"
+        "Enter 'yes' to save or 'no' to cancel."
+    )


### PR DESCRIPTION
- Added export_tool_prompt function in prompts/export_tool.py to generate context-aware export decisions
- Updated should_export method in GraphNodes to use the new prompt generation
- Refined export_notes tool description to emphasize explicit user export requests
- Removed unnecessary print statement in normal_chat_response method